### PR TITLE
Support  Date in string format, and prevent error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,12 @@
  * @returns {Boolean} `true` if the date is valid, `false` otherwise.
  */
 module.exports = function dateIsValid (d) {
+    // prevent error message in case of an invalid entry
+    try {
+        d.getTime();
+    } catch (error) {
+        d = new Date(d);
+    }
     let t = d.getTime();
     return t === t;
 };

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "test": "node test"
   },
   "author": "Ionică Bizău <bizauionica@gmail.com> (https://ionicabizau.net)",
+  "contributors": [
+    "Desiderio Silva <desideriotbs@gmail.com> (https://github.com/dsilva01)"
+ ],
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/IonicaBizau/date-is-valid.git"


### PR DESCRIPTION
## Add support  Date in string format, and prevent error
### E.g fix
> > > > ```js
> > > > const dateIsInvalid = require("data-is-valid")
> > > > 
> > > > console.log(dateIsInvalid("1970-05-10")); 
> > > > 
> > > > console.log(dateIsInvalid("dfs"));
> > > > ```
> > > > 
> > > > 
> > > >     
> > > >       
> > > >     
> > > > 
> > > >       
> > > >     
> > > > 
> > > >     
> > > >   
> > > > The expected output is `true`, as `1970-05-10` is a date. It logs `Error` instead.
> > > > The expected output is `false`, as `dfs` is a string. It logs `Error` instead.

