### PR TITLE
Refactored code to give a more accurate answer

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,5 @@
  * @returns {Boolean} `true` if the date is valid, `false` otherwise.
  */
 module.exports = function dateIsValid (d) {
-    let t = d.getTime();
-    return t === t;
+    return d instanceof Date && !isNaN(d);
 };


### PR DESCRIPTION
if d.gettime() is undefined then `t` would be undefined.
and the following operation `t === t` would be true which shouldn't be the case for an invalid date.
